### PR TITLE
Force async when fetching image by url

### DIFF
--- a/src/tools/browser-image-tools.ts
+++ b/src/tools/browser-image-tools.ts
@@ -12,7 +12,7 @@ export const browserImageTools = {
           reader.readAsDataURL(xhr.response);
         };
         xhr.onerror = xhr.onabort = xhr.ontimeout = reject;
-        xhr.open("GET", url);
+        xhr.open("GET", url, true);
         xhr.responseType = "blob";
         xhr.send();
       } else {


### PR DESCRIPTION
Ran into issues when trying to use images in the QR where the image is from a URL.

I was getting "The response type cannot be changed for synchronous requests made from a document.".

Doesn't seem to make sense as requests are asynchronous by default, but a bit of research found that some libraries have been known to patch the `open` call in a way that leads to calls ending up synchronous if you don't explicitly set `async` param to `true`.

This very small change sets the `async` param on the `open` call to true to make sure there are no problems.