### PR TITLE
feat(dots): add "wave" dot type

### DIFF
--- a/examples/playground/index.html
+++ b/examples/playground/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>QR Styling Playground</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <script type="module">
+      // Import the ESM build. Your lib/ listing shows qr-code-styling.js exists.
+      import * as QR from "../../lib/qr-code-styling.js";
+
+      // Different builds export differently; this normalization covers the common cases.
+      const QRCodeStyling = QR.default ?? QR.QRCodeStyling ?? QR;
+
+      console.log("Module keys:", Object.keys(QR));
+      console.log("Ctor:", QRCodeStyling);
+
+      const qr = new QRCodeStyling({
+        width: 300,
+        height: 300,
+        data: "https://naigc.org",
+        dotsOptions: { type: "wave", color: "#0b3d62" },
+        backgroundOptions: { color: "#ffffff" }
+      });
+
+      qr.append(document.getElementById("app"));
+    </script>
+  </body>
+</html>

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -14,7 +14,8 @@ export enum DotType {
     square = 'square',
     smallSquare = 'small-square',
     tinySquare = 'tiny-square',
-    diamond = 'diamond'
+    diamond = 'diamond',
+    wave = 'wave'
 }
 
 export enum CornerDotType {


### PR DESCRIPTION
**Summary**
Adds a new dot style `dotsOptions.type: "wave"`.

**Behavior**
- 0 neighbors → circle
- exactly 1 neighbor → wave (flat base on the shared edge; pointy crest pointing counterclockwise)
- 2 neighbors on opposite sides, or 3–4 neighbors → square
- 2 neighbors on adjacent sides → square with the far (diagonal) corner rounded

**Implementation notes**
- New helper `basicWave` constructs a 3-node shape with two cubic Béziers; crest at top edge (x + 0.2·size) in base orientation, rotated via `rotateFigure`.
- Reuses existing neighbor-count flow (mirrors `drawRounded`), adds dispatcher case for `DotType.wave`.
- All SVG elements created with proper SVG namespace + typed casts (e.g., `SVGPathElement`).

**Testing**
- `yarn test` passes locally.
- Manual QA: renders in playground; scanned successfully in 2 apps at small and large sizes.

**Docs**
- No README changes in this PR (happy to add a short example on request).

**Screenshots**
(attach 1–2 PNGs: overall sample + zoom of a single-neighbor module)
<img width="389" height="389" alt="{D3B2F623-DEA6-49A4-8221-C71F3DD55766}" src="https://github.com/user-attachments/assets/37f2e375-f943-4d92-a576-20b615a08058" />
<img width="302" height="205" alt="{EAA433C7-33F4-4F4D-9BFC-CAEC4D8F4C26}" src="https://github.com/user-attachments/assets/40903d86-f42b-43ed-84e9-5c330cde45d2" />

